### PR TITLE
Fix travis uglify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: lisp
 sudo: required
+dist: trusty
 
 git:
   submodules: false
@@ -25,7 +26,6 @@ before_install:
 install:
   - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh
   - sh -c 'make deps || true'
-#  - bin/ensure-sane-sbcl
 
 script:
   - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
   - git submodule update --init --recursive
   - echo "Installing UglifyJS"
   - sudo apt-get update
-  - sudo apt-get install -ynpm
+  - sudo apt-get install -y npm
   - npm install uglifyjs
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,10 @@ before_install:
   - echo "Installing UglifyJS"
   - sudo apt-get update
   - sudo apt-get install -y npm
-  - npm install -g uglify-js
+  # NB. NPM now installs  the breaking, backward-incompatible, α-quality
+  # version  3 by  default,  which  is *not*  what  we  want. Trying  to
+  # convince it to load the latest v2.* here.
+  - npm install -g uglify-js@2
 
 install:
   - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - echo "Installing UglifyJS"
   - sudo apt-get update
   - sudo apt-get install -y npm
-  - npm install uglifyjs
+  - npm install uglify-js
 
 install:
   - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - echo "Installing UglifyJS"
   - sudo apt-get update
   - sudo apt-get install -y npm
-  - npm install uglify-js
+  - npm install -g uglify-js
 
 install:
   - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ before_install:
   - git submodule sync
   - echo "Updating submodules"
   - git submodule update --init --recursive
+  - echo "Installing UglifyJS"
+  - sudo apt-get update
+  - sudo apt-get install -ynpm
+  - npm install uglifyjs
 
 install:
   - curl -L https://github.com/luismbo/cl-travis/raw/master/install.sh | sh

--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ js/mesh.yug.js: js/mesh.js src/lib/jscl/jscl.js
 
 js/%.yug.js: src/js/%.js
 	uglifyjs $< \
-		--source-map static/$@.map \
+		--source-map=static/$@.map \
 		--screw-ie8 \
 		-o $@ \
 		-m -c		
@@ -143,7 +143,7 @@ js/%.cc.js: src/js/%.js
 
 js/jscl.yug.js: src/lib/jscl/jscl.js
 	uglifyjs $< \
-		--source-map static/$@.map \
+		--source-map=static/$@.map \
 		--screw-ie8 \
 		-o $@ \
 		-m -c		

--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,6 @@ doc:	doc/violet-volts.pdf doc/violet-volts.info doc/violet-volts.txt \
 
 doc/violet-volts.texi:	tootstest.cgi
 	./tootstest.cgi write-docs
-	ln doc/tootstest.texi doc/violet-volts.texi
+	ln -f doc/tootstest.texi doc/violet-volts.texi
 
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ js/mesh.cc.js:	js/mesh.js js/undef-require.js src/lib/jscl/jscl.js
 
 js/mesh.yug.js: js/mesh.js src/lib/jscl/jscl.js
 	uglifyjs src/lib/jscl/jscl.js js/mesh.js \
-		--source-map static/$@.map \
+		--source-map=static/$@.map \
 		--screw-ie8 \
 		-o js/mesh.yug.js \
 		-m -c		

--- a/src/main.lisp
+++ b/src/main.lisp
@@ -122,7 +122,7 @@ Quicklisp when called."
     (ensure-directories-exist (merge-pathnames #p"doc/" source-dir))
     (funcall (intern "DECLT" (find-package :net.didierverna.declt))
              :tootstest
-             :library-name "Violet Volts: tootstest"
+             :library "Violet Volts: tootstest"
              :texi-file (merge-pathnames #p"doc/tootstest.texi"
                                          source-dir)
              :info-file (merge-pathnames #p "doc/tootstest"


### PR DESCRIPTION
The UglifyJS step has been failing on Travis, and I finally got time to poke at it. It seems that NPM has decided to change its default version to an incompatible one (wrt. command-line arguments, at least), which breaks the build. In deference to the primary build machines being Fedora-25 and Fedora-26, both of which are still working, this PR is trying to force Travis to run compatibly.